### PR TITLE
Changed TQ to question and answer markdown format & Added tQ demo to styledguidist 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.5.0-rc1",
+  "version": "1.5.0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.5.0",
+  "version": "1.6.0-rc0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.6.0-rc2",
+  "version": "1.6.0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.6.0-rc0",
+  "version": "1.6.0-rc1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.6.0-rc1",
+  "version": "1.6.0-rc2",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -26,10 +26,10 @@ const CardContent = ({
       <BlockEditable
         preview={markdownView}
         markdown={markdown}
+        editable={false}
         style={{
           fontSize,
         }}
-        // onEdit={_markdown => onMarkdownChange(_markdown)}
       />
     )
   } else if (item && item.markdown && viewMode === 'markdown') {
@@ -37,10 +37,10 @@ const CardContent = ({
       <BlockEditable
         preview={markdownView}
         markdown={item.markdown}
+        editable={false}
         style={{
           fontSize,
         }}
-        // onEdit={_markdown => onMarkdownChange(_markdown)}
       />
     )
   } else if (item && viewMode === 'list') {
@@ -51,6 +51,23 @@ const CardContent = ({
         fontSize={fontSize}
         setQuote={setQuote}
         selectedQuote={selectedQuote}
+      />
+    )
+  } else if (item && viewMode === 'question') {
+    const text = item?.Annotation.replace('', '')
+    const chunks = text.split('?')
+    const question = chunks[0]
+    const answer = chunks[1].split('> ')[1]
+    const markdown = `# ${question}? \n\n${answer.trim()}`
+
+    return (
+      <BlockEditable
+        preview={markdownView}
+        markdown={markdown}
+        editable={false}
+        style={{
+          fontSize,
+        }}
       />
     )
   } else if (
@@ -104,7 +121,13 @@ CardContent.propTypes = {
   setQuote: PropTypes.func,
   markdownView: PropTypes.bool,
   selectedQuote: PropTypes.object,
-  viewMode: PropTypes.oneOf(['default', 'table', 'list', 'markdown']),
+  viewMode: PropTypes.oneOf([
+    'default',
+    'table',
+    'list',
+    'markdown',
+    'question',
+  ]),
 }
 
 export default CardContent

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -66,6 +66,7 @@ const CardContent = ({
         markdown={markdown}
         editable={false}
         style={{
+          display: 'block',
           fontSize,
         }}
       />

--- a/src/components/CardContent/CardContent.md
+++ b/src/components/CardContent/CardContent.md
@@ -362,3 +362,77 @@ const Component = () => {
 
 <Component/>
 ```
+
+## Translation Questions Example
+
+```jsx
+import React, { useState } from 'react'
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Card from '../Card'
+import useContent from '../../hooks/useContent.js'
+import useCardState from '../../hooks/useCardState.js'
+
+const Component = () => {
+   const { markdown, items, resource, isLoading, props: { languageId } } = useContent({
+    verse: 1,
+    chapter: 1,
+    projectId: 'tit',
+    branch: 'master',
+    languageId: 'en',
+    resourceId: 'tq',
+    filePath: null,
+    owner: 'test_org',
+    server: 'https://git.door43.org',
+  })
+
+  const {
+    state: {
+      item,
+      headers,
+      filters,
+      fontSize,
+      itemIndex,
+      markdownView,
+    },
+    actions: {
+      setFilters,
+      setFontSize,
+      setItemIndex,
+      setMarkdownView,
+    }
+  } = useCardState({
+    items,
+  })
+
+  console.log({items})
+
+  return (
+    <Card
+      items={items}
+      title={'translationQuestions'}
+      headers={headers}
+      filters={filters}
+      fontSize={fontSize}
+      itemIndex={itemIndex}
+      setFilters={setFilters}
+      setFontSize={setFontSize}
+      setItemIndex={setItemIndex}
+      markdownView={markdownView}
+      setMarkdownView={setMarkdownView}
+    >
+      <CardContent
+        item={item}
+        filters={filters}
+        fontSize={fontSize}
+        markdown={markdown}
+        viewMode='question'
+        isLoading={isLoading}
+        languageId={languageId}
+        markdownView={markdownView}
+      />
+    </Card>
+  )
+}
+
+<Component/>
+```

--- a/src/components/TsvContent/TsvContent.js
+++ b/src/components/TsvContent/TsvContent.js
@@ -53,9 +53,9 @@ const Label = styled.label`
 const Item = ({
   label,
   value,
+  error,
   fontSize,
   caution,
-  error,
   setQuote,
   Occurrence,
   selectedQuote,
@@ -116,10 +116,10 @@ const Item = ({
 const TsvContent = ({
   item,
   filters,
-  markdownView,
-  fontSize: _fontSize,
   setQuote,
+  markdownView,
   selectedQuote,
+  fontSize: _fontSize,
 }) => {
   const fontSize = _fontSize === 100 ? 'inherit' : `${_fontSize}%`
   const { Annotation, Occurrence } = item
@@ -127,6 +127,7 @@ const TsvContent = ({
     <BlockEditable
       preview={markdownView}
       markdown={Annotation}
+      editable={false}
       style={{
         fontSize,
         padding: '0px',


### PR DESCRIPTION
- Changed TQ to question and answer markdown format & Added tQ demo to styledguidist 

## Test Instructions

- Open https://deploy-preview-26--translation-helps-rcl.netlify.app/#cardcontent
- Scroll to the `Translation Questions Example`
- Should see tQ formatted in question and answer text as shown in https://github.com/unfoldingword/create-app/issues/39
- Text should not be editable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translation-helps-rcl/26)
<!-- Reviewable:end -->
