### PR TITLE
Bugfix/fix inverted logic for markdown view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.8.1-alpha",
+  "version": "1.8.1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",
@@ -12,8 +12,7 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline",
-    "postpublish": "git tag v$npm_package_version && git push origin v$npm_package_version"
+    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.7.1",
+  "version": "1.7.2-alpha",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline"
+    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline",
+    "postpublish": "git tag v$npm_package_version && git push origin v$npm_package_version"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.x",

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -24,7 +24,7 @@ const CardContent = ({
   } else if (markdown && typeof markdown === 'string') {
     return (
       <BlockEditable
-        preview={markdownView}
+        preview={!markdownView}
         markdown={markdown}
         editable={false}
         style={{
@@ -35,7 +35,7 @@ const CardContent = ({
   } else if (item && item.markdown && viewMode === 'markdown') {
     return (
       <BlockEditable
-        preview={markdownView}
+        preview={!markdownView}
         markdown={item.markdown}
         editable={false}
         style={{
@@ -62,7 +62,7 @@ const CardContent = ({
 
     return (
       <BlockEditable
-        preview={markdownView}
+        preview={!markdownView}
         markdown={markdown}
         editable={false}
         style={{

--- a/src/components/TsvContent/TsvContent.js
+++ b/src/components/TsvContent/TsvContent.js
@@ -125,7 +125,7 @@ const TsvContent = ({
   const { Annotation, Occurrence } = item
   const AnnotationMarkdown = (
     <BlockEditable
-      preview={markdownView}
+      preview={!markdownView}
       markdown={Annotation}
       editable={false}
       style={{

--- a/src/hooks/useCardState.js
+++ b/src/hooks/useCardState.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react'
 const useCardState = ({ items }) => {
   const [itemIndex, setItemIndex] = useState(0)
   const item = items ? items[itemIndex] : null
-  const [markdownView, setMarkdownView] = useState(true)
+  const [markdownView, setMarkdownView] = useState(false)
   const [fontSize, setFontSize] = useState(100)
   const [headers, setHeaders] = useState([])
   const [filters, setFilters] = useState([])


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] fixed inverted logic for showing markdown view
- [ ] changed useCardState to initialize to not showing markdown

## Test Instructions
- can test using https://deploy-preview-30--translation-helps-rcl.netlify.app/
- [ ] go through all the examples and check the card settings.  Make sure markdown toggle defaults to off.  Make sure when toggle is turned on that the card switches to show markdown.
- can test with https://deploy-preview-74--create-app.netlify.app/
- [ ] go through all the cards and check the card settings.  If the card has a markdown toggle, make sure it defaults to off.  Make sure when toggle is turned on that the card switches to show markdown.
