### PR TITLE
Added errorMessage prop to card content 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.8.1",
+  "version": "1.9.0-rc0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -11,9 +11,10 @@ const CardContent = ({
   filters,
   markdown,
   viewMode,
-  isLoading,
   setQuote,
+  isLoading,
   markdownView,
+  errorMessage,
   selectedQuote,
   fontSize: _fontSize,
 }) => {
@@ -21,6 +22,24 @@ const CardContent = ({
 
   if (isLoading) {
     return <CircularProgress size={200} />
+  } else if (errorMessage) {
+    return (
+      <div style={{ fontSize: '1.3rem', height: '100%' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '35px 0px',
+            fontWeight: 'bold',
+            height: '100%',
+            fontSize,
+          }}
+        >
+          {errorMessage}
+        </div>
+      </div>
+    )
   } else if (markdown && typeof markdown === 'string') {
     return (
       <BlockEditable
@@ -116,11 +135,12 @@ CardContent.propTypes = {
   item: PropTypes.object,
   items: PropTypes.array,
   filters: PropTypes.array,
+  setQuote: PropTypes.func,
   isLoading: PropTypes.bool,
   markdown: PropTypes.string,
   fontSize: PropTypes.number,
-  setQuote: PropTypes.func,
   markdownView: PropTypes.bool,
+  errorMessage: PropTypes.string,
   selectedQuote: PropTypes.object,
   viewMode: PropTypes.oneOf([
     'default',


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] Open https://deploy-preview-31--translation-helps-rcl.netlify.app/#cardcontent
- [x] Below the `TSV Content Example` click on `VIEW CODE`
- [x] Add  `errorMessage="Hello World!"` as a prop to the CardContent component
- [x] The message "Hello World!" should render in the center of the card in the demo above
- [ ] Open https://deploy-preview-79--create-app.netlify.app/
- [x] If the current note has an empty SupportReference field, the translation academy card should read `No article is specified in the current note` otherwise it should render the appropriate article 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translation-helps-rcl/31)
<!-- Reviewable:end -->
