### PR TITLE
Feature/helpful missing content messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.10.0",
+  "version": "1.11.0-alpha",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.11.0-alpha",
+  "version": "1.11.0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -15,7 +15,6 @@ import SettingsCard from '../SettingsCard'
 const useStyles = makeStyles(() => ({
   title: {
     fontSize: '16px',
-    lineHeight: '2rem',
     fontWeight: 'bold',
     fontFamily: `Noto Sans`,
     maxWidth: '100%',
@@ -81,6 +80,7 @@ const Card = ({
   markdownView,
   setItemIndex,
   onRemoveCard,
+  onMenuClose,
   disableFilters,
   setMarkdownView,
   disableNavigation,
@@ -111,6 +111,7 @@ const Card = ({
 
   const onMenuClick = () => {
     setShowMenu(!showMenu)
+    onMenuClose && onMenuClose()
   }
 
   const onPrevItem = () => {
@@ -241,6 +242,8 @@ Card.propTypes = {
   settingsTitle: PropTypes.string,
   /** Function fired when the close (x) icon is clicked */
   onClose: PropTypes.func,
+  /** Function called when menu is closed */
+  onMenuClose: PropTypes.func,
   /** Content/jsx render in the body of the card */
   children: PropTypes.node.isRequired,
   /** Array of TSV header filters (this is array of header items that are currently selected) */

--- a/src/components/Card/Card.md
+++ b/src/components/Card/Card.md
@@ -63,6 +63,7 @@ const Component = () => {
       settingsTitle={settingsTitle}
       setMarkdownView={setMarkdownView}
       onClose={() => console.log('closed')}
+      onMenuClose={() => console.log('menu closed')}
       onRemoveCard={onRemoveCard}
       hideMarkdownToggle={hideMarkdownToggle}
     >


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] added onMenuClose() to properties of Card.  This allows us to clear the error Message when settings card is closed.
- [ ] removed duplicate lineHeight

## Test Instructions
- test with https://deploy-preview-33--translation-helps-rcl.netlify.app/#card
- [ ] open console in chrome debugger
- [ ] open settings on Card example
- [ ] close the card and should see message `menu closed` come up in console.
