### PR TITLE
Feature/Auto Scroll to Top

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.13.4-alpha",
+  "version": "1.13.4",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.13.3",
+  "version": "1.13.4-alpha",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Badge from '@material-ui/core/Badge'
@@ -11,6 +11,7 @@ import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import Paper from '../Paper'
 import SettingsCard from '../SettingsCard'
+import Scrollable from "../Scrollable"
 
 const useStyles = makeStyles(() => ({
   title: {
@@ -78,29 +79,6 @@ const Navigation = ({
     />
   </FlexSpacedDiv>
 )
-
-const Scrollable = ({ className, children, itemIndex }) => {
-  const scrollRef = useRef(null);
-
-  useEffect(() => {
-    setTimeout(() => {
-      scrollRef.current?.scrollTo(0, 0);
-    }, 100)
-  }, [itemIndex]);
-
-  return <div ref={scrollRef} className={className}>
-    {children}
-  </div>
-}
-
-Scrollable.propTypes = {
-  /** Current item index */
-  itemIndex: PropTypes.number,
-  /** Function called when menu is closed */
-  className: PropTypes.string.isRequired,
-  /** Content/jsx render in the body of the card */
-  children: PropTypes.node.isRequired,
-}
 
 const Card = ({
   id,

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, {useState, useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Badge from '@material-ui/core/Badge'
@@ -61,6 +61,29 @@ const Navigation = ({ items, classes, itemIndex, onPrevItem, onNextItem, baseId 
     <ChevronRightIcon className={classes.chevronIcon} id={`${baseId}_next`} onClick={onNextItem} />
   </FlexSpacedDiv>
 )
+
+const Scrollable = ({ className, children, itemIndex }) => {
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      scrollRef.current?.scrollTo(0, 0);
+    }, 100)
+  }, [itemIndex]);
+
+  return <div ref={scrollRef} className={className}>
+    {children}
+  </div>
+}
+
+Scrollable.propTypes = {
+  /** Current item index */
+  itemIndex: PropTypes.number,
+  /** Function called when menu is closed */
+  className: PropTypes.string.isRequired,
+  /** Content/jsx render in the body of the card */
+  children: PropTypes.node.isRequired,
+}
 
 const Card = ({
   alert,
@@ -202,9 +225,11 @@ const Card = ({
           </FlexDiv>
         )}
       </FlexSpacedDiv>
-      <div className={`${classes.children} ${childrenClassName}`}>
-        {children}
-      </div>
+      <Scrollable
+        className={`${classes.children} ${childrenClassName}`}
+        children={children}
+        itemIndex={itemIndex}
+      />
     </Paper>
   )
 }

--- a/src/components/Scrollable/Scrollable.js
+++ b/src/components/Scrollable/Scrollable.js
@@ -1,0 +1,28 @@
+import React, { useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
+
+
+export const Scrollable = ({ className, children, itemIndex }) => {
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      scrollRef.current?.scrollTo(0, 0);
+    }, 100)
+  }, [itemIndex]);
+
+  return <div ref={scrollRef} className={className}>
+    {children}
+  </div>
+}
+
+Scrollable.propTypes = {
+  /** Current item index, used as trigger to scroll to top */
+  itemIndex: PropTypes.number,
+  /** Function called when menu is closed */
+  className: PropTypes.string.isRequired,
+  /** Content/jsx render in the body of the card */
+  children: PropTypes.node.isRequired,
+}
+
+export default Scrollable

--- a/src/components/Scrollable/index.js
+++ b/src/components/Scrollable/index.js
@@ -1,0 +1,1 @@
+export { default } from './Scrollable'


### PR DESCRIPTION
## Describe what your pull request addresses
- [ ] auto scroll contents to top when itemIndex changes on reference card

## Test Instructions
- can test with
- [ ] go to test_org, en, mat 1:2 (for an example that has a lot of navigation)
- [ ] on tN card, test auto scrolling by scrolling down on card and then click on navigation chevrons.  When text updates, card should go back to top
- [ ] on tWA card test auto scrolling by scrolling down on card and then click on navigation chevrons.  When text updates, card should go back to top
- [ ] on tQ card test auto scrolling by scrolling down on card and then click on navigation chevrons.  When text updates, card should go back to top
- [ ] content should display as before
