### PR TITLE
Added word-break to text in resource cards

### DIFF
--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -31,13 +31,14 @@ const CardContent = ({
       <div style={{ fontSize: '1.3rem', height: '100%' }}>
         <div
           style={{
+            fontSize,
+            height: '100%',
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
             padding: '35px 0px',
             fontWeight: 'bold',
-            height: '100%',
-            fontSize,
+            wordBreak: 'break-word',
           }}
         >
           {errorMessage}

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -16,12 +16,13 @@ const useStyles = makeStyles(() => ({
 }))
 
 const Message = styled.div`
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 35px 0px;
   font-weight: bold;
-  height: 100%;
+  word-break: break-word;
   font-size: ${({ fontSize }) => (fontSize ? fontSize : '100%')};
 `
 


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] Open https://deploy-preview-153--gateway-edit.netlify.app/
- [ ] Select `test_org2`, `English` and Mat 1:1
- [ ] Resize `translationWords List`, `translationWords Article` and `translationAcademy` cards to reduce the width 
- [ ] The status message should not look like picture A but like picture B
`A` ![Screen Shot 2021-04-08 at 11 44 09 AM](https://user-images.githubusercontent.com/17072300/114056879-1c0f9e00-9860-11eb-905e-cba9e0c77b89.png)

`B`
![Screen Shot 2021-04-08 at 11 49 56 AM](https://user-images.githubusercontent.com/17072300/114057445-8fb1ab00-9860-11eb-9606-197be31f124d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translation-helps-rcl/41)
<!-- Reviewable:end -->
