### PR TITLE
Fixed bug with OLQuote click in tN card bringing the card to 1st note 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc2",
+  "version": "1.46.7-rc3",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc6",
+  "version": "1.46.7-rc7",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc0",
+  "version": "1.46.7-rc1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc9",
+  "version": "1.46.7-rc10",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",
@@ -49,7 +49,6 @@
   "dependencies": {
     "axios": "^0.21.1",
     "react-draggable": "^4.4.3",
-    "styled-components": "^5.2.1",
-    "use-deep-compare-effect": "^1.6.1"
+    "styled-components": "^5.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.6",
+  "version": "1.46.7-rc0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc7",
+  "version": "1.46.7-rc8",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc3",
+  "version": "1.46.7-rc4",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.14.6",
+  "version": "1.46.6",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc8",
+  "version": "1.46.7-rc9",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",
@@ -49,6 +49,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "react-draggable": "^4.4.3",
-    "styled-components": "^5.2.1"
+    "styled-components": "^5.2.1",
+    "use-deep-compare-effect": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc4",
+  "version": "1.46.7-rc5",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc1",
+  "version": "1.46.7-rc2",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc5",
+  "version": "1.46.7-rc6",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/CardContent/CardContent.md
+++ b/src/components/CardContent/CardContent.md
@@ -228,7 +228,7 @@ import useContent from '../../hooks/useContent.js'
 import useCardState from '../../hooks/useCardState.js'
 
 const Component = () => {
-  const [selectedQuote, setQuote] = useState({})
+  const [selectedQuote, setQuote] = useState(null)
   const { markdown, items, isLoading, props: { languageId } } = useContent({
     verse: 1,
     chapter: 1,

--- a/src/components/TsvContent/TsvContent.js
+++ b/src/components/TsvContent/TsvContent.js
@@ -89,7 +89,7 @@ const Item = ({
               occurrence: Occurrence,
               SupportReference,
             })
-          else if (setQuote && selected) setQuote({})
+          else if (setQuote && selected) setQuote(null)
         }}
       >
         <Legend

--- a/src/hooks/useCardState.js
+++ b/src/hooks/useCardState.js
@@ -1,6 +1,13 @@
 import { useState, useEffect } from 'react'
 
-const useCardState = ({ items, selectedQuote = {}, setQuote }) => {
+const useCardState = ({
+  items,
+  verse,
+  chapter,
+  setQuote,
+  projectId,
+  selectedQuote = {},
+}) => {
   const [itemIndex, setItemIndex] = useState(0)
   const item = items ? items[itemIndex] : null
   const [markdownView, setMarkdownView] = useState(false)
@@ -8,6 +15,10 @@ const useCardState = ({ items, selectedQuote = {}, setQuote }) => {
   const [headers, setHeaders] = useState([])
   const [filters, setFilters] = useState([])
   const { SupportReference, quote, occurrence } = selectedQuote || {}
+
+  useEffect(() => {
+    setItemIndex(0)
+  }, [verse, chapter, projectId])
 
   useEffect(() => {
     if (items && typeof SupportReference === 'string') {
@@ -26,11 +37,9 @@ const useCardState = ({ items, selectedQuote = {}, setQuote }) => {
         }
       )
 
-      if (index >= 0) {
+      if (index >= 0 && index !== itemIndex) {
         setItemIndex(index)
       }
-    } else {
-      setItemIndex(0)
     }
   }, [items, SupportReference, quote, occurrence])
 


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] Open https://deploy-preview-166--gateway-edit.netlify.app/
- [ ] Clicking on the OL Quote should not jump the TN card to the first record in the verse. The card should remain as it is.
- [ ] See the following video as a reference to what used to happen:
https://images.zenhubusercontent.com/310359593/76e5ffcb-4238-46d4-bafa-2c9ba5322671/video_mp4__1534x890_.mp4


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/translation-helps-rcl/45)
<!-- Reviewable:end -->
