### PR TITLE
Feature 130/improve http error handling and add checking for network 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.17-alpha",
+  "version": "1.46.17",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.7-rc10",
+  "version": "1.46.8-alpha",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -99,7 +99,7 @@ DraggableCard.defaultProps = {
 DraggableCard.propTypes = {
   /** Determines whether the DraggableCard is opened or not */
   open: PropTypes.bool.isRequired,
-  /** if true then content in not processed */
+  /** if true then content is not processed */
   showRawContent: PropTypes.bool,
   /** The title of the card */
   title: PropTypes.string,

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -34,11 +34,15 @@ export default function DraggableCard({
   onClose,
   loading,
   fontSize,
+  id,
+  showRawContent,
 }) {
   const classes = useStyles()
 
   function getCardContent() {
-    if (error) {
+    if (showRawContent) {
+      return content
+    } else if (error) {
       return (
         <Message fontSize={fontSize}>
           Sorry, there was a problem loading the content.
@@ -65,7 +69,7 @@ export default function DraggableCard({
 
   return (
     <DraggableModal
-      id='draggable_article_card'
+      id={id}
       open={open}
       title={title || ''}
       handleClose={onClose}
@@ -86,16 +90,22 @@ export default function DraggableCard({
 }
 
 DraggableCard.defaultProps = {
+  id: 'draggable_article_card',
   title: '',
   content: '',
   fontSize: '100%',
+  showRawContent: false,
 }
 
 DraggableCard.propTypes = {
   /** Determines whether the DraggableCard is opened or not */
   open: PropTypes.bool.isRequired,
+  /** if true then content in not processed */
+  showRawContent: PropTypes.bool,
   /** The title of the card */
   title: PropTypes.string,
+  /** identifier for the card */
+  id: PropTypes.string,
   /** DraggableCard content */
   content: PropTypes.oneOfType([
     PropTypes.string,


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] tweaked DraggableCard to show raw content

## Test Instructions

- [ ] test with https://deploy-preview-196--gateway-edit.netlify.app/
- with PC network connected:
  - [ ] launch app
  - [ ] login
  - [ ] in account settings change org to `test_org` language to `cmn-x-omc`, and click save and continue
  - [ ] should see warning that GLT could not be found:
  
![Screen Shot 2021-05-12 at 1 20 08 PM](https://user-images.githubusercontent.com/14238574/118030593-8326e380-b333-11eb-935b-47bc1bdb7f92.png)

  - [ ] click send feedback
  - [ ] fill out bug reports - I just used `t` for all text fields (so email would be invalid)
  - [ ] click submit and should see error:
  
![Screen Shot 2021-05-12 at 1 26 32 PM](https://user-images.githubusercontent.com/14238574/118030729-ad78a100-b333-11eb-8a53-a61906fcdda5.png)

  - [ ] click close
  - [ ] fill out bug reports - this time I just used `test@test.com` for all text fields
  - [ ] this time it should succeed

- disconnect PC from network (with WIFI connection it's easy to disable  WIFI for testing)
  - [ ] click submit and this time should see Network error:

![Screen Shot 2021-05-12 at 1 29 34 PM](https://user-images.githubusercontent.com/14238574/118034387-eca8f100-b337-11eb-8777-ba142563724d.png)

  - [ ] click close to close network error dialog
  - [ ] in drawer select logout
  - [ ] try to log in and should see error popup:

![Screen Shot 2021-05-12 at 2 15 48 PM](https://user-images.githubusercontent.com/14238574/118035329-11519880-b339-11eb-9f8e-a95463bb67ea.png)


- connect to PC network
  - [ ] once network shows connected, click close
  - [ ] try to login and it should succeed
  - [ ] should take you back to feedback page.  click X to close
  - [ ] should take to resource page and see the invalid resource prompt again:

![Screen Shot 2021-05-12 at 1 20 08 PM](https://user-images.githubusercontent.com/14238574/118035895-da2fb700-b339-11eb-819b-6f25ef7231a4.png)


  - [ ] click cancel
  - [ ] go to account settings and select en as language.  Click save and continue and should not see error.

- disconnect PC from network
  - [ ] go to account setup
  - [ ] should eventually see networking error (may need to timeout)



- connect PC to network
  - [ ] once network shows connected, click retry
  - [ ] this time should be no error and orgs should load

