### PR TITLE
Made resource layout responsive 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.17-rc0",
+  "version": "1.46.18-rc0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "1.46.16",
+  "version": "1.46.17-rc0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -21,10 +21,11 @@ const useStyles = makeStyles(() => ({
     maxWidth: '100%',
     color: '#424242',
     lineHeight: '14px',
+    wordBreak: 'break-word',
   },
   dragIcon: {
     color: '#ECECEC',
-    margin: '0px 10px 0px 0px',
+    margin: '0px',
     cursor: props => (props.dragging ? 'grabbing' : 'grab'),
   },
   chevronIcon: {
@@ -38,7 +39,7 @@ const useStyles = makeStyles(() => ({
     height: '100%',
     overflow: 'auto',
     textAlign: 'start',
-    padding: '4px 0px 0px 4px',
+    padding: '0px 6px',
   },
   paddingRight: {
     padding: '0px 15px 0px 0px',
@@ -53,6 +54,14 @@ const FlexDiv = styled.div`
 const FlexSpacedDiv = styled.div`
   display: flex;
   justify-content: space-between;
+`
+
+const NavigationFlexDiv = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 3px;
+  width: 100%;
 `
 
 const Navigation = ({
@@ -167,18 +176,6 @@ const Card = ({
           />
           <div className={classes.title}>{title}</div>
         </FlexDiv>
-        <FlexDiv>
-          {!disableNavigation && items && items.length > 1 && (
-            <Navigation
-              baseId={id}
-              items={items}
-              classes={classes}
-              itemIndex={itemIndex}
-              onPrevItem={onPrevItem}
-              onNextItem={onNextItem}
-            />
-          )}
-        </FlexDiv>
         {closeable ? (
           <CloseIcon
             id='settings_card_close'
@@ -224,6 +221,20 @@ const Card = ({
             )}
           </FlexDiv>
         )}
+      </FlexSpacedDiv>
+      <FlexSpacedDiv className={header}>
+        <NavigationFlexDiv>
+        {!disableNavigation && items && items.length > 1 && (
+            <Navigation
+              baseId={id}
+              items={items}
+              classes={classes}
+              itemIndex={itemIndex}
+              onPrevItem={onPrevItem}
+              onNextItem={onNextItem}
+            />
+          )}
+        </NavigationFlexDiv>
       </FlexSpacedDiv>
       <Scrollable
         className={`${classes.children} ${childrenClassName}`}

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -51,15 +51,17 @@ const CardContent = ({
         markdown={markdown}
         fontSize={fontSize}
         preview={!markdownView}
+        style={{ padding: '0px' }}
       />
     )
   } else if (item && item.markdown && viewMode === 'markdown') {
     return (
       <BlockEditable
         preview={!markdownView}
-        markdown={stripReferenceLinksFromMarkdown(item.markdown)}
         editable={false}
         fontSize={fontSize}
+        style={{ padding: '0px' }}
+        markdown={stripReferenceLinksFromMarkdown(item.markdown)}
       />
     )
   } else if (item && viewMode === 'list') {
@@ -97,9 +99,7 @@ const CardContent = ({
         markdown={markdown}
         editable={false}
         fontSize={fontSize}
-        style={{
-          display: 'block',
-        }}
+        style={{ display: 'block', padding: '0px' }}
       />
     )
   } else if (

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 const Paper = styled.div`
   margin: 2.5px;
-  padding: 16px;
+  padding: 10px;
   border-radius: 2px;
   position: relative;
   transition: all 0.2s ease-in-out;

--- a/src/components/TsvContent/TsvContent.js
+++ b/src/components/TsvContent/TsvContent.js
@@ -10,7 +10,7 @@ const Container = styled.div`
   row-gap: 1.5rem;
   column-gap: 1rem;
   width: 100%;
-  padding: 10px 0px 0px;
+  padding: 0px;
   margin: 7px 0px 0px;
 `
 


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] Open https://deploy-preview-199--gateway-edit.netlify.app/
- [ ] Change your window width to 900px the layout should adjust and no card content should overflow the card.
- [ ] If you change the layout it should persist for that window size (681px - 900px)
- [ ] Now reduce the width down below 680px
- [ ] The layout should rearrange based on the window size. Changing the layout should be persisted for this window size (0px - 680px)
- [ ] Replace the contents of `[USERNAME]_resourceLayout` in localstorage for `https://deploy-preview-199--gateway-edit.netlify.app/` with the contents of `[USERNAME]_resourceLayout` in https://gateway-edit.netlify.app/ 
- [ ] It should maintain the same layout but only when the window size is 900px or above. 
