### PR TITLE
Feature 157/limit drag on tA cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.7",
+  "version": "2.3.1-alpha.8",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.2",
+  "version": "2.3.1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.0",
+  "version": "2.3.1-alpha.2",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.11",
+  "version": "2.3.1-alpha.12",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",
@@ -12,7 +12,8 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline"
+    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline",
+    "postpublish": "git tag v$npm_package_version && git push origin v$npm_package_version"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.12",
+  "version": "2.3.1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.6",
+  "version": "2.3.1-alpha.7",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1",
+  "version": "2.3.1-alpha.5",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1",
+  "version": "2.3.1-alpha.11",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",
@@ -12,8 +12,7 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline",
-    "postpublish": "git tag v$npm_package_version && git push origin v$npm_package_version"
+    "prepublishOnly": "rm -rf ./dist && babel ./src --out-dir ./dist -s inline"
   },
   "peerDependencies": {
     "@material-ui/core": "^4.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.8",
+  "version": "2.3.1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "2.3.1-alpha.5",
+  "version": "2.3.1-alpha.6",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -319,7 +319,7 @@ Card.propTypes = {
   /** Current item index */
   itemIndex: PropTypes.number,
   /** Root ref, used as reference for drag action */
-  dragRef: PropTypes.node,
+  dragRef: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
   /** Show alert icon */
   alert: PropTypes.bool,
   /** Show dragging icon when card is dragged */

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import DraggableModal from '../DraggableModal'
 import Card from '../Card'
 import stripReferenceLinksFromMarkdown from '../../core/stripReferenceLinksFromMarkdown'
+import isEqual from 'deep-equal'
 
 const useStyles = makeStyles(() => ({
   card: {
@@ -67,18 +68,20 @@ export default function DraggableCard({
         right,
         bottom,
       }
-      setBounds(newBounds)
+      if (!isEqual(bounds, newBounds)) { // update if changed
+        setBounds(newBounds)
+      }
     } else {
       setBounds(null)
     }
   }, [
     parentRef?.current,
-    cardRef?.current?.offsetLeft,
-    cardRef?.current?.offsetTop,
-    cardRef?.current?.offsetParent?.offsetLeft,
-    cardRef?.current?.offsetParent?.offsetTop,
+    cardRef?.current,
+    // we watch the following because displayed content changes trigger card resizing
     content,
-    loading
+    loading,
+    error,
+    showRawContent
   ])
 
   function getCardContent() {
@@ -106,20 +109,6 @@ export default function DraggableCard({
     }
   }
 
-  function onStopDrag(e) {
-    console.log('DraggableCard.onStopDrag', e)
-    const { clientX, clientY } = e
-    const { clientHeight, clientWidth } = parentRef?.current || {}
-    console.log({ clientX, clientY, clientHeight, clientWidth })
-    const min = 0
-    if (parentRef?.current) {
-      if ((clientX < min) || (clientY < min)
-        || (clientX > clientWidth - min) || (clientY > clientHeight - min)) {
-        console.log('outside of range')
-      }
-    }
-  }
-
   title = error ? 'Error' : title
 
   return (
@@ -128,7 +117,6 @@ export default function DraggableCard({
       open={open}
       title={title || ''}
       handleClose={onClose}
-      onStopDrag={onStopDrag}
       bounds={bounds}
     >
       <Card
@@ -181,6 +169,4 @@ DraggableCard.propTypes = {
   ]),
   /** Optional, used to make sure draggable card is contained within parent */
   parentRef: PropTypes.object,
-  // /** optional drag limits */
-  // bounds: PropTypes.object,
 }

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -59,8 +59,9 @@ export default function DraggableCard({
       let bottom = clientTop + clientHeight - offsetTop;
 
       // tweak right and bottom so draggable handle stays on screen
-      right -= cardOffsetLeft
-      bottom -= cardOffsetTop
+      const scrollBarFactor = 1.25 // in case workspace scroll bar is visible (browser dependent)
+      right -= Math.round(cardOffsetLeft * scrollBarFactor)
+      bottom -= Math.round(cardOffsetTop * scrollBarFactor)
 
       const newBounds = {
         left: clientLeft - offsetLeft,

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -50,7 +50,7 @@ export default function DraggableCard({
       let offsetLeft = cardOffsetLeft
       let offsetTop = cardOffsetTop
 
-      if (cardRef.current.offsetParent) { // add parent offset if present
+      if (cardRef.current.offsetParent) { // add card parent offset if present
         offsetLeft += cardRef.current.offsetParent.offsetLeft
         offsetTop += cardRef.current.offsetParent.offsetTop
       }
@@ -71,13 +71,13 @@ export default function DraggableCard({
       if (!isEqual(bounds, newBounds)) { // update if changed
         setBounds(newBounds)
       }
-    } else {
+    } else if (bounds !== null) {
       setBounds(null)
     }
   }, [
     parentRef?.current,
     cardRef?.current,
-    // we watch the following because displayed content changes trigger card resizing
+    // we watch the following because displayed content changes trigger card resizing and recentering
     content,
     loading,
     error,

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import BlockEditable from 'markdown-translatable/dist/components/block-editable'
@@ -36,8 +36,10 @@ export default function DraggableCard({
   fontSize,
   id,
   showRawContent,
+  parentRef,
 }) {
   const classes = useStyles()
+  const cardRef = useRef(null)
 
   function getCardContent() {
     if (showRawContent) {
@@ -64,6 +66,21 @@ export default function DraggableCard({
     }
   }
 
+  function onStop(e) {
+    console.log('onStop', e)
+    const { clientX, clientY, screenX, screenY } = e
+    const {
+      clientHeight,
+      clientWidth,
+    } = parentRef?.current || {}
+    console.log({ clientX, clientY, clientHeight, clientWidth })
+    const min = 48;
+    if ( (clientX < min) || (clientY < min)
+    || (clientX > clientWidth - min) || (clientY > clientHeight - min)) {
+      console.log('outside of range')
+    }
+  }
+
   title = error ? 'Error' : title
 
   return (
@@ -72,6 +89,8 @@ export default function DraggableCard({
       open={open}
       title={title || ''}
       handleClose={onClose}
+      cardRef={cardRef}
+      onStop={onStop}
     >
       <Card
         closeable
@@ -94,6 +113,7 @@ DraggableCard.defaultProps = {
   content: '',
   fontSize: '100%',
   showRawContent: false,
+  mainScreenRef: null,
 }
 
 DraggableCard.propTypes = {
@@ -119,4 +139,6 @@ DraggableCard.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  /** Used to make sure card is on screen if defined */
+  parentRef: PropTypes.object,
 }

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -43,10 +43,10 @@ export default function DraggableCard({
   const cardRef = useRef(null)
   const [ bounds, setBounds ] = useState(null)
 
-  useEffect(() => {
+  function updateBounds() {
     if (parentRef?.current?.clientWidth && parentRef?.current?.clientHeight && cardRef?.current) {
-      const { clientLeft, clientWidth, clientTop, clientHeight } = parentRef.current
-      const { offsetLeft: cardOffsetLeft, offsetTop: cardOffsetTop } = cardRef.current
+      const {clientLeft, clientWidth, clientTop, clientHeight} = parentRef.current
+      const {offsetLeft: cardOffsetLeft, offsetTop: cardOffsetTop} = cardRef.current
       let offsetLeft = cardOffsetLeft
       let offsetTop = cardOffsetTop
 
@@ -75,6 +75,10 @@ export default function DraggableCard({
     } else if (bounds !== null) {
       setBounds(null)
     }
+  }
+
+  useEffect(() => {
+    updateBounds()
   }, [
     parentRef?.current,
     cardRef?.current,
@@ -110,6 +114,13 @@ export default function DraggableCard({
     }
   }
 
+  function onStartDrag() {
+    // drag started, do check to see if drag bounds need to be updated
+    if (parentRef?.current) {
+      updateBounds()
+    }
+  }
+
   title = error ? 'Error' : title
 
   return (
@@ -119,6 +130,7 @@ export default function DraggableCard({
       title={title || ''}
       handleClose={onClose}
       bounds={bounds}
+      onStartDrag={onStartDrag}
     >
       <Card
         closeable

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -37,7 +37,7 @@ export default function DraggableCard({
   fontSize,
   id,
   showRawContent,
-  parentRef,
+  workspaceRef,
 }) {
   const classes = useStyles()
   const cardRef = useRef(null)
@@ -52,7 +52,7 @@ export default function DraggableCard({
     state: { bounds },
     actions: { updateBounds },
   } = useBoundsUpdater({
-    parentRef,
+    workspaceRef,
     cardRef,
     displayState
   })
@@ -84,7 +84,7 @@ export default function DraggableCard({
 
   function onStartDrag() {
     // drag started, do check to see if drag bounds need to be updated
-    if (parentRef?.current) {
+    if (workspaceRef?.current) {
       const updated = updateBounds()
       if (updated) {
         return false
@@ -126,7 +126,7 @@ DraggableCard.defaultProps = {
   content: '',
   fontSize: '100%',
   showRawContent: false,
-  parentRef: null,
+  workspaceRef: null,
 }
 
 DraggableCard.propTypes = {
@@ -152,6 +152,6 @@ DraggableCard.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
-  /** Optional, used to make sure draggable card is contained within parent */
-  parentRef: PropTypes.object,
+  /** Optional, used to make sure draggable card is contained within workspace */
+  workspaceRef: PropTypes.object,
 }

--- a/src/components/DraggableCard/DraggableCard.js
+++ b/src/components/DraggableCard/DraggableCard.js
@@ -43,6 +43,10 @@ export default function DraggableCard({
   const cardRef = useRef(null)
   const [ bounds, setBounds ] = useState(null)
 
+  /**
+   * determines if bounds have changed for dragging
+   * @return {boolean} returns true if bounds changed
+   */
   function updateBounds() {
     if (parentRef?.current?.clientWidth && parentRef?.current?.clientHeight && cardRef?.current) {
       const {clientLeft, clientWidth, clientTop, clientHeight} = parentRef.current
@@ -71,10 +75,13 @@ export default function DraggableCard({
       }
       if (!isEqual(bounds, newBounds)) { // update if changed
         setBounds(newBounds)
+        return true
       }
     } else if (bounds !== null) {
       setBounds(null)
+      return true
     }
+    return false
   }
 
   useEffect(() => {
@@ -117,8 +124,12 @@ export default function DraggableCard({
   function onStartDrag() {
     // drag started, do check to see if drag bounds need to be updated
     if (parentRef?.current) {
-      updateBounds()
+      const updated = updateBounds()
+      if (updated) {
+        return false
+      }
     }
+    return true
   }
 
   title = error ? 'Error' : title

--- a/src/components/DraggableModal/DraggableModal.js
+++ b/src/components/DraggableModal/DraggableModal.js
@@ -8,21 +8,14 @@ export default function DraggableModal({
   handleClose,
   children,
   id,
-  onStopDrag,
   bounds,
  }) {
 
   function PaperComponent(props) {
-    function onStop_(e) {
-      console.log('PaperComponent.onStop_', e)
-      onStopDrag && onStopDrag(e)
-    }
-
     return (
       <Draggable
         handle='.draggable-dialog-title'
         cancel={'[class*="MuiDialogContent-root"]'}
-        onStop={onStop_}
         bounds={bounds}
       >
         <div {...props} />
@@ -55,8 +48,6 @@ DraggableModal.propTypes = {
   handleClose: PropTypes.func.isRequired,
   /** Modal Content */
   children: PropTypes.element.isRequired,
-  /** callback for drag stop */
-  onStopDrag: PropTypes.func,
   /** optional drag limits */
   bounds: PropTypes.object,
 }

--- a/src/components/DraggableModal/DraggableModal.js
+++ b/src/components/DraggableModal/DraggableModal.js
@@ -4,17 +4,18 @@ import Dialog from '@material-ui/core/Dialog'
 import Draggable from 'react-draggable'
 
 export default function DraggableModal({
-   open,
-   handleClose,
-   children,
-   id,
-   onStop,
+  open,
+  handleClose,
+  children,
+  id,
+  onStopDrag,
+  bounds,
  }) {
 
   function PaperComponent(props) {
     function onStop_(e) {
       console.log('PaperComponent.onStop_', e)
-      onStop && onStop(e)
+      onStopDrag && onStopDrag(e)
     }
 
     return (
@@ -22,6 +23,7 @@ export default function DraggableModal({
         handle='.draggable-dialog-title'
         cancel={'[class*="MuiDialogContent-root"]'}
         onStop={onStop_}
+        bounds={bounds}
       >
         <div {...props} />
       </Draggable>
@@ -53,4 +55,8 @@ DraggableModal.propTypes = {
   handleClose: PropTypes.func.isRequired,
   /** Modal Content */
   children: PropTypes.element.isRequired,
+  /** callback for drag stop */
+  onStopDrag: PropTypes.func,
+  /** optional drag limits */
+  bounds: PropTypes.object,
 }

--- a/src/components/DraggableModal/DraggableModal.js
+++ b/src/components/DraggableModal/DraggableModal.js
@@ -8,14 +8,21 @@ export default function DraggableModal({
   handleClose,
   children,
   id,
+  onStartDrag,
   bounds,
  }) {
 
   function PaperComponent(props) {
+    function onStart(e) {
+      onStartDrag && onStartDrag(e)
+      return true
+    }
+
     return (
       <Draggable
         handle='.draggable-dialog-title'
         cancel={'[class*="MuiDialogContent-root"]'}
+        onStart={onStart}
         bounds={bounds}
       >
         <div {...props} />
@@ -48,6 +55,8 @@ DraggableModal.propTypes = {
   handleClose: PropTypes.func.isRequired,
   /** Modal Content */
   children: PropTypes.element.isRequired,
+  /** optional callback for drag start */
+  onStartDrag: PropTypes.func,
   /** optional drag limits */
   bounds: PropTypes.object,
 }

--- a/src/components/DraggableModal/DraggableModal.js
+++ b/src/components/DraggableModal/DraggableModal.js
@@ -3,18 +3,31 @@ import PropTypes from 'prop-types'
 import Dialog from '@material-ui/core/Dialog'
 import Draggable from 'react-draggable'
 
-function PaperComponent(props) {
-  return (
-    <Draggable
-      handle='.draggable-dialog-title'
-      cancel={'[class*="MuiDialogContent-root"]'}
-    >
-      <div {...props} />
-    </Draggable>
-  )
-}
+export default function DraggableModal({
+   open,
+   handleClose,
+   children,
+   id,
+   onStop,
+ }) {
 
-export default function DraggableModal({ open, handleClose, children, id }) {
+  function PaperComponent(props) {
+    function onStop_(e) {
+      console.log('PaperComponent.onStop_', e)
+      onStop && onStop(e)
+    }
+
+    return (
+      <Draggable
+        handle='.draggable-dialog-title'
+        cancel={'[class*="MuiDialogContent-root"]'}
+        onStop={onStop_}
+      >
+        <div {...props} />
+      </Draggable>
+    )
+  }
+
   return (
     <Dialog
       open={open}

--- a/src/components/DraggableModal/DraggableModal.js
+++ b/src/components/DraggableModal/DraggableModal.js
@@ -14,7 +14,9 @@ export default function DraggableModal({
 
   function PaperComponent(props) {
     function onStart(e) {
-      onStartDrag && onStartDrag(e)
+      if (onStartDrag) {
+        return onStartDrag(e)
+      }
       return true
     }
 

--- a/src/core/glQuotes.js
+++ b/src/core/glQuotes.js
@@ -139,7 +139,7 @@ export async function getGlAlignmentBibles(languageId, httpConfig, server, owner
   // remove chapter and verse so we get back whole book of the bible
   delete reference_.chapter
   delete reference_.verse
-  for (const glBible of glBibleList) {
+  for (const glBible of glBibleList || []) {
     const bible = await loadGlBible(glBible, config, 'master', reference_)
     if (bible) {
       glBibles_.push(bible)

--- a/src/core/glQuotes.js
+++ b/src/core/glQuotes.js
@@ -48,7 +48,7 @@ export const getAlignedText = (verseObjects, quote, occurrenceToMatch, isMatch=f
       if (isMatch || wordsToMatch.find(item => (verseObject.content === item.word) && (verseObject.occurrence === item.occurrence))) {
         lastMatch = true;
 
-        // We have a match (or previoiusly had a match in the parent) so we want to include all text that we find,
+        // We have a match (or previously had a match in the parent) so we want to include all text that we find,
         if (needsEllipsis) {
           // Need to add an ellipsis to the separator since a previous match but not one right next to this one
           separator += ELLIPSIS+DEFAULT_SEPARATOR;

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useBoundsUpdater } from './useBoundsUpdater'
 export { default as useContent } from './useContent'
 export { default as useCardState } from './useCardState'
 export { default as useUserBranch } from './useUserBranch'

--- a/src/hooks/useBoundsUpdater.js
+++ b/src/hooks/useBoundsUpdater.js
@@ -3,13 +3,13 @@ import isEqual from 'deep-equal'
 
 /**
  * monitors for changes in changes in draggable bounds.  Provides updateBounds() so that it can be updated by external events.
- * @param parentRef
- * @param cardRef
- * @param displayState
+ * @param {object} workspaceRef - reference for workspace to get size of the workspace
+ * @param {object} cardRef - reference of draggable card content
+ * @param {object} displayState - object that contains the values that control displayed size
  * @return {{state: {headers: *, item: *, itemIndex: *, fontSize: (string|*), filters: (*|*[]), markdownView: *}, actions: {setMarkdownView: *, setItemIndex: *, setFilters: *, setFontSize: *}}}
  */
 const useBoundsUpdater = ({
-  parentRef,
+  workspaceRef,
   cardRef,
   displayState
 }) => {
@@ -20,8 +20,8 @@ const useBoundsUpdater = ({
    * @return {boolean} returns true if bounds changed
    */
   function updateBounds() {
-    if (parentRef?.current?.clientWidth && parentRef?.current?.clientHeight && cardRef?.current) {
-      const {clientLeft, clientWidth, clientTop, clientHeight} = parentRef.current
+    if (workspaceRef?.current?.clientWidth && workspaceRef?.current?.clientHeight && cardRef?.current) {
+      const {clientLeft, clientWidth, clientTop, clientHeight} = workspaceRef.current
       const {offsetLeft: cardOffsetLeft, offsetTop: cardOffsetTop} = cardRef.current
       let offsetLeft = cardOffsetLeft
       let offsetTop = cardOffsetTop
@@ -59,11 +59,9 @@ const useBoundsUpdater = ({
   useEffect(() => {
     updateBounds()
   }, [
-    {
-      parentCurrent: parentRef?.current,
-      cardCurrent: cardRef?.current,
-      displayState,
-    }
+    workspaceRef?.current,
+    cardRef?.current,
+    displayState
   ])
 
   return {

--- a/src/hooks/useBoundsUpdater.js
+++ b/src/hooks/useBoundsUpdater.js
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import isEqual from 'deep-equal'
+
+/**
+ * monitors for changes in changes in draggable bounds.  Provides updateBounds() so that it can be updated by external events.
+ * @param parentRef
+ * @param cardRef
+ * @param displayState
+ * @return {{state: {headers: *, item: *, itemIndex: *, fontSize: (string|*), filters: (*|*[]), markdownView: *}, actions: {setMarkdownView: *, setItemIndex: *, setFilters: *, setFontSize: *}}}
+ */
+const useBoundsUpdater = ({
+  parentRef,
+  cardRef,
+  displayState
+}) => {
+  const [ bounds, setBounds ] = useState(null)
+
+  /**
+   * determines if bounds have changed for dragging
+   * @return {boolean} returns true if bounds changed
+   */
+  function updateBounds() {
+    if (parentRef?.current?.clientWidth && parentRef?.current?.clientHeight && cardRef?.current) {
+      const {clientLeft, clientWidth, clientTop, clientHeight} = parentRef.current
+      const {offsetLeft: cardOffsetLeft, offsetTop: cardOffsetTop} = cardRef.current
+      let offsetLeft = cardOffsetLeft
+      let offsetTop = cardOffsetTop
+
+      if (cardRef.current.offsetParent) { // add card parent offset if present
+        offsetLeft += cardRef.current.offsetParent.offsetLeft
+        offsetTop += cardRef.current.offsetParent.offsetTop
+      }
+
+      let right = clientLeft + clientWidth - offsetLeft;
+      let bottom = clientTop + clientHeight - offsetTop;
+
+      // tweak right and bottom so draggable handle stays on screen
+      const scrollBarFactor = 1.25 // in case workspace scroll bar is visible (browser dependent)
+      right -= Math.round(cardOffsetLeft * scrollBarFactor)
+      bottom -= Math.round(cardOffsetTop * scrollBarFactor)
+
+      const newBounds = {
+        left: clientLeft - offsetLeft,
+        top: clientTop - offsetTop,
+        right,
+        bottom,
+      }
+      if (!isEqual(bounds, newBounds)) { // update if changed
+        setBounds(newBounds)
+        return true
+      }
+    } else if (bounds !== null) {
+      setBounds(null)
+      return true
+    }
+    return false
+  }
+
+  useEffect(() => {
+    updateBounds()
+  }, [
+    {
+      parentCurrent: parentRef?.current,
+      cardCurrent: cardRef?.current,
+      displayState,
+    }
+  ])
+
+  return {
+    state: { bounds },
+    actions: { updateBounds },
+  }
+}
+
+export default useBoundsUpdater


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] updated draggable card so that if parent reference is passed, we set drag bounds so that card stays on screen

## Test Instructions
- test with https://deploy-preview-276--gateway-edit.netlify.app/
- [ ] open and log into app.  Select an org and language
- [ ] find a ta article that has a link (for test_org/en you can use Heb 1:7 metaphor)
- [ ] make sure that as you drag the card around, that the drag icon is always visible

# Reviewable: https://reviewable.io/reviews/unfoldingWord/translation-helps-rcl/66#-