### PR TITLE
Fixed bug where editing tNotes or tQs would add line breaks that subsequently broke TSV files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "3.1.2",
+  "version": "3.1.3-rc1",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/TqContent/TqContent.js
+++ b/src/components/TqContent/TqContent.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { BlockEditable } from 'markdown-translatable'
+import cleanMarkdownLineBreak from '../../core/cleanMarkdownLineBreak'
 
 export default function TsvContent({
   item,
@@ -37,7 +38,8 @@ export default function TsvContent({
 
   const handleEdit = (field, edit) => {
     // Remove markdown that was added for view only
-    const newEdit = edit?.replace('#', '')
+    let newEdit = edit?.replace('#', '')
+    newEdit = cleanMarkdownLineBreak(edit)
 
     setTqValue(prevState => ({
       ...prevState,

--- a/src/components/TsvContent/TsvContent.js
+++ b/src/components/TsvContent/TsvContent.js
@@ -220,8 +220,6 @@ const Item = ({
               margin: markdownView ? '10px 0px 0px' : '-5px 0px 0px',
             }}
             onEdit={markdown => {
-              console.log('markdown', markdown)
-              console.log('clean markdown', cleanMarkdownLineBreak(markdown))
               setUpdatedItem('markdown', cleanMarkdownLineBreak(markdown))
               onTsvEdit({ [markdownLabel]: cleanMarkdownLineBreak(markdown) })
             }}

--- a/src/components/TsvContent/TsvContent.js
+++ b/src/components/TsvContent/TsvContent.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { BlockEditable } from 'markdown-translatable'
 import getNoteLabel from '../../core/getNoteLabel'
+import cleanMarkdownLineBreak from '../../core/cleanMarkdownLineBreak'
 
 export default function TsvContent({
   id,
@@ -219,8 +220,10 @@ const Item = ({
               margin: markdownView ? '10px 0px 0px' : '-5px 0px 0px',
             }}
             onEdit={markdown => {
-              setUpdatedItem('markdown', markdown)
-              onTsvEdit({ [markdownLabel]: markdown })
+              console.log('markdown', markdown)
+              console.log('clean markdown', cleanMarkdownLineBreak(markdown))
+              setUpdatedItem('markdown', cleanMarkdownLineBreak(markdown))
+              onTsvEdit({ [markdownLabel]: cleanMarkdownLineBreak(markdown) })
             }}
           />
         ) : isEditable ? (

--- a/src/core/cleanMarkdownLineBreak.js
+++ b/src/core/cleanMarkdownLineBreak.js
@@ -1,0 +1,3 @@
+export default function cleanMarkdownLineBreak(markdown) {
+  return markdown.replace(/\n/g, '<br>')
+}

--- a/src/hooks/useTsvMerger.js
+++ b/src/hooks/useTsvMerger.js
@@ -24,6 +24,7 @@ export default function useTsvMerger({
       const newTsvs = Object.assign({}, { ...tsvsState })
       // Updating item reference with edited item.
       const oldItem = { ...newTsvs[chapter][verse][itemIndex] }
+      console.log('onTsvEdit newItem', newItem)
       newTsvs[chapter][verse][itemIndex] = { ...oldItem, ...newItem }
       setTsvsState(newTsvs)
       const tsvItems = flattenObject(newTsvs)

--- a/src/hooks/useTsvMerger.js
+++ b/src/hooks/useTsvMerger.js
@@ -24,7 +24,6 @@ export default function useTsvMerger({
       const newTsvs = Object.assign({}, { ...tsvsState })
       // Updating item reference with edited item.
       const oldItem = { ...newTsvs[chapter][verse][itemIndex] }
-      console.log('onTsvEdit newItem', newItem)
       newTsvs[chapter][verse][itemIndex] = { ...oldItem, ...newItem }
       setTsvsState(newTsvs)
       const tsvItems = flattenObject(newTsvs)


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] First delete your user branches on both tN and tQ repos if you previously encountered this bug. 
- [x] Open https://deploy-preview-305--gateway-edit.netlify.app/
- [x] Add two new lines after existing translation Note text.
- [x] Now add some text.
- [x] Click save.
- [x] Your edits should save correctly. 
- [x] Now repeat the same steps for translation Questions. 
- [x] Your edits should save correctly. 
