### PR TITLE
Mk card toolbar & card settings extensible

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "webpack": "4.44.0"
   },
   "dependencies": {
+    "@gwdevs/extensible-rcl": "^1.0.0",
     "axios": "^0.21.1",
     "deep-equal": "^2.0.5",
     "react-draggable": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-rcl",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "main": "dist",
   "homepage": "https://translation-helps-rcl.netlify.app/",
   "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -379,10 +379,16 @@ Card.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   /** The title settings popup.  Optional, if not given, it will be created from title */
   settingsTitle: PropTypes.string,
+  /** callback function to customize the the body of the settings card */
+  onRenderSettings: PropTypes.func,
   /** Function fired when the close (x) icon is clicked */
   onClose: PropTypes.func,
   /** Function called when menu is closed */
   onMenuClose: PropTypes.func,
+  /** callback function to customize the the body of the card toolbar.
+   * @return {element}
+   */
+  onRenderToolbar: PropTypes.func,
   /** Content/jsx render in the body of the card */
   children: PropTypes.node.isRequired,
   /** Array of TSV header filters (this is array of header items that are currently selected) */

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -14,10 +14,11 @@ import IconButton from '@material-ui/core/IconButton'
 import SaveOutlinedIcon from '@material-ui/icons/SaveOutlined'
 import VisibilityIcon from '@material-ui/icons/Visibility'
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff'
-import MinimizeIcon from '@material-ui/icons/Minimize';
+import MinimizeIcon from '@material-ui/icons/Minimize'
 import Paper from '../Paper'
 import SettingsCard from '../SettingsCard'
 import Scrollable from '../Scrollable'
+import { Extensible } from '@gwdevs/extensible-rcl'
 
 const useStyles = makeStyles(() => ({
   title: {
@@ -122,6 +123,8 @@ const Card = ({
   disableFilters,
   cardResourceId,
   setMarkdownView,
+  onRenderToolbar,
+  onRenderSettings,
   disableNavigation,
   hideMarkdownToggle,
   getCustomComponent,
@@ -224,57 +227,59 @@ const Card = ({
           />
         ) : (
           <FlexDiv>
-            {alert && (
-              <IconButton
-                aria-label='warning'
-                onClick={onAlertClick}
-                className={classes.margin}
-              >
-                <Badge color='secondary' variant='dot'>
-                  <AnnouncementIcon htmlColor='#000' />
-                </Badge>
-              </IconButton>
-            )}
-            {!!onMinimize ? (
-              <IconButton
-                title='Minimize'
-                aria-label='Minimize'
-                onClick={() => onMinimize()}
-                className={classes.margin}
-              >
-                <MinimizeIcon id='minimize_icon' htmlColor='#000' />
-              </IconButton>
-            ) : null}
-            {!hideMarkdownToggle ? (
-              <IconButton
-                title={markdownView ? 'Preview' : 'Markdown'}
-                aria-label={markdownView ? 'Preview' : 'Markdown'}
-                onClick={() => setMarkdownView(!markdownView)}
-                className={classes.margin}
-              >
-                {markdownView ? (
-                  <VisibilityOffIcon id='visibility_icon' htmlColor='#000' />
-                ) : (
-                  <VisibilityIcon id='visibility_icon' htmlColor='#000' />
-                )}
-              </IconButton>
-            ) : null}
-            {editable ? (
-              <IconButton
-                disabled={saved}
-                className={classes.margin}
-                onClick={() => onSaveEdit()}
-                title={saved ? 'Saved' : 'Save'}
-                aria-label={saved ? 'Saved' : 'Save'}
-                style={{ cursor: saved ? 'none' : 'pointer ' }}
-              >
-                {saved ? (
-                  <SaveOutlinedIcon id='saved_icon' />
-                ) : (
-                  <SaveIcon id='save_icon' htmlColor='#000' />
-                )}
-              </IconButton>
-            ) : null}
+            <Extensible onRenderItems={onRenderToolbar}>
+              {alert && (
+                <IconButton
+                  aria-label='warning'
+                  onClick={onAlertClick}
+                  className={classes.margin}
+                >
+                  <Badge color='secondary' variant='dot'>
+                    <AnnouncementIcon htmlColor='#000' />
+                  </Badge>
+                </IconButton>
+              )}
+              {!!onMinimize ? (
+                <IconButton
+                  title='Minimize'
+                  aria-label='Minimize'
+                  onClick={() => onMinimize()}
+                  className={classes.margin}
+                >
+                  <MinimizeIcon id='minimize_icon' htmlColor='#000' />
+                </IconButton>
+              ) : null}
+              {!hideMarkdownToggle ? (
+                <IconButton
+                  title={markdownView ? 'Preview' : 'Markdown'}
+                  aria-label={markdownView ? 'Preview' : 'Markdown'}
+                  onClick={() => setMarkdownView(!markdownView)}
+                  className={classes.margin}
+                >
+                  {markdownView ? (
+                    <VisibilityOffIcon id='visibility_icon' htmlColor='#000' />
+                  ) : (
+                    <VisibilityIcon id='visibility_icon' htmlColor='#000' />
+                  )}
+                </IconButton>
+              ) : null}
+              {editable ? (
+                <IconButton
+                  disabled={saved}
+                  className={classes.margin}
+                  onClick={() => onSaveEdit()}
+                  title={saved ? 'Saved' : 'Save'}
+                  aria-label={saved ? 'Saved' : 'Save'}
+                  style={{ cursor: saved ? 'none' : 'pointer ' }}
+                >
+                  {saved ? (
+                    <SaveOutlinedIcon id='saved_icon' />
+                  ) : (
+                    <SaveIcon id='save_icon' htmlColor='#000' />
+                  )}
+                </IconButton>
+              ) : null}
+            </Extensible>
             {showMenu && (
               <SettingsCard
                 title={settingsTitle}
@@ -289,6 +294,7 @@ const Card = ({
                 onRemoveCard={onRemoveCard}
                 disableFilters={disableFilters}
                 onShowMarkdown={setMarkdownView}
+                onRenderSettings={onRenderSettings}
                 hideMarkdownToggle={hideMarkdownToggle}
                 getCustomComponent={getCustomComponent}
               />

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -233,6 +233,7 @@ const Card = ({
                   aria-label='warning'
                   onClick={onAlertClick}
                   className={classes.margin}
+                  key='alert-button'
                 >
                   <Badge color='secondary' variant='dot'>
                     <AnnouncementIcon htmlColor='#000' />
@@ -242,6 +243,7 @@ const Card = ({
               {!!onMinimize ? (
                 <IconButton
                   title='Minimize'
+                  key='minimize-button'
                   aria-label='Minimize'
                   onClick={() => onMinimize()}
                   className={classes.margin}
@@ -252,6 +254,7 @@ const Card = ({
               {!hideMarkdownToggle ? (
                 <IconButton
                   title={markdownView ? 'Preview' : 'Markdown'}
+                  key='preview-button'
                   aria-label={markdownView ? 'Preview' : 'Markdown'}
                   onClick={() => setMarkdownView(!markdownView)}
                   className={classes.margin}
@@ -267,6 +270,7 @@ const Card = ({
                 <IconButton
                   disabled={saved}
                   className={classes.margin}
+                  key='save-button'
                   onClick={() => onSaveEdit()}
                   title={saved ? 'Saved' : 'Save'}
                   aria-label={saved ? 'Saved' : 'Save'}

--- a/src/components/Card/Card.md
+++ b/src/components/Card/Card.md
@@ -87,41 +87,77 @@ const Component = () => {
 
 The content of the Card toolbar and the Card settings can be customized using the **onRenderSettings** and **onRenderToolbar** props.
 
-**Examples:**
+**Example:**
 
 ```js
+import useCardState from '../../hooks/useCardState.js'
+import Button from '@material-ui/core/Button'
+
 const CustomToolbarButton = ({onClick}) => {
-  return <button onClick={onClick}>Custom Toolbar Button</button>
+  return <Button variant="contained" onClick={onClick}>🔍 Custom Button</Button>
 }
 
 const CustomSettingComponent = () => {
   return (
-    <>
-      <h4>Custom setting</h4>
+    <label>
+      <p>Custom setting</p>
       <input type="range" min="1" step="1" max="100" defaultValue="50"/>
-    </>
+    </label>
   );
 }
 
 const CustomCard = () => {
 
+  const {
+    state: {
+      item,
+      headers,
+      filters,
+      fontSize,
+      itemIndex,
+      markdownView,
+    },
+    actions: {
+      setFilters,
+      setFontSize,
+      setItemIndex,
+      setMarkdownView,
+    }
+  } = useCardState({
+    items: []
+  })
+
+  //Example returning jsx
   const onRenderSettings = ({items}) => {
-    const slicedItems = items.slice(-1); //Slice or filter desired items.
-    return <><CustomSettingComponent/>{slicedItems}</>//Example returning jsx
+    const divider = items.find(item => item.key === "divider");
+    return <><CustomSettingComponent/>{divider}{items}</>
   }
 
+  //Example returning array
   const onRenderToolbar = ({items}) => [
     ...items,
-    <CustomToolbarButton onClick={ () => alert("Custom Toolbar Button clicked") }/>
-  ] //Example returning array
+    <CustomToolbarButton key="custom-button" onClick={ () => alert("Custom Toolbar Button clicked") }/>
+  ]
 
   return (
     <Card
-      title="Custom card"
-      alert
       onRenderToolbar={onRenderToolbar}
       onRenderSettings={onRenderSettings}
-      //...other required props
+      //Other required props:
+      alert
+      headers={headers}
+      filters={filters}
+      title="Custom card"
+      fontSize={fontSize}
+      itemIndex={itemIndex}
+      setFilters={setFilters}
+      setFontSize={setFontSize}
+      setItemIndex={setItemIndex}
+      markdownView={markdownView}
+      setMarkdownView={setMarkdownView}
+      onClose={() => console.log('closed')}
+      onMenuClose={() => console.log('menu closed')}
+      hideMarkdownToggle={false}
     >
       Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
     </Card>
@@ -131,4 +167,8 @@ const CustomCard = () => {
 <CustomCard/>
 ```
 
-<small>*Note: Both **onRenderSettings** and **onRenderToolbar** callback functions can return either jsx or an array of children for their respective parents*</small>
+<small>
+  Notes:
+    1. Both **onRenderSettings** and **onRenderToolbar** callback functions can return either jsx or an array of children for their respective parents.
+    2. Using filter, map, reduce array methods is adviced when manipulating the items array.
+</small>

--- a/src/components/Card/Card.md
+++ b/src/components/Card/Card.md
@@ -82,3 +82,53 @@ const Component = () => {
 
 <Component/>
 ```
+
+## Customizing settings card and Card toolbar
+
+The content of the Card toolbar and the Card settings can be customized using the **onRenderSettings** and **onRenderToolbar** props.
+
+**Examples:**
+
+```js
+const CustomToolbarButton = ({onClick}) => {
+  return <button onClick={onClick}>Custom Toolbar Button</button>
+}
+
+const CustomSettingComponent = () => {
+  return (
+    <>
+      <h4>Custom setting</h4>
+      <input type="range" min="1" step="1" max="100" defaultValue="50"/>
+    </>
+  );
+}
+
+const CustomCard = () => {
+
+  const onRenderSettings = ({items}) => {
+    const slicedItems = items.slice(-1); //Slice or filter desired items.
+    return <><CustomSettingComponent/>{slicedItems}</>//Example returning jsx
+  }
+
+  const onRenderToolbar = ({items}) => [
+    ...items,
+    <CustomToolbarButton onClick={ () => alert("Custom Toolbar Button clicked") }/>
+  ] //Example returning array
+
+  return (
+    <Card
+      title="Custom card"
+      alert
+      onRenderToolbar={onRenderToolbar}
+      onRenderSettings={onRenderSettings}
+      //...other required props
+    >
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+    </Card>
+  )
+}
+
+<CustomCard/>
+```
+
+<small>*Note: Both **onRenderSettings** and **onRenderToolbar** callback functions can return either jsx or an array of children for their respective parents*</small>

--- a/src/components/SettingsCard/SettingsCard.js
+++ b/src/components/SettingsCard/SettingsCard.js
@@ -7,6 +7,7 @@ import FormGroup from '@material-ui/core/FormGroup'
 import { makeStyles, withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
+import { Extensible } from '@gwdevs/extensible-rcl'
 import DraggableModal from '../DraggableModal'
 import FontSizeSlider from '../FontSizeSlider'
 import Card from '../Card'
@@ -98,6 +99,7 @@ const SettingsCard = ({
   onRemoveCard,
   onShowMarkdown,
   disableFilters,
+  onRenderSettings,
   hideMarkdownToggle,
   getCustomComponent,
 }) => {
@@ -132,71 +134,73 @@ const SettingsCard = ({
           dragIndicator: 'draggable-dialog-title',
         }}
       >
-        <FormGroup row classes={{ row: classes.formGroup }}>
-          {!hideMarkdownToggle && (
-            <FormControlLabel
-              control={
-                <BlueSwitch
-                  name='markdownView'
-                  checked={markdownView}
-                  onClick={() => onShowMarkdown(!markdownView)}
-                />
-              }
-              classes={{ label: classes.switchLabel }}
-              label='Markdown View'
-              labelPlacement='bottom'
-            />
-          )}
-          {!!getCustomComponent && getCustomComponent()}
-        </FormGroup>
-        <Divider />
-        <div className={classes.fontSlider}>
-          <FontSizeSlider value={fontSize} onChange={setFontSize} />
-        </div>
-        {!disableFilters && headers && headers.length > 0 && (
-          <Fragment>
-            <Divider />
-            <div className={classes.section}>
-              <div className={classes.columns}>
-                <Typography
-                  classes={{ root: classes.typography }}
-                  variant='caption'
-                  display='block'
-                  gutterBottom
-                >
-                  Show Columns
-                </Typography>
-                <div className={classes.checkboxes}>
-                  {headers.map((header, i) => (
-                    <FormControlLabel
-                      key={`${i}-${header}`}
-                      label={header}
-                      classes={{ root: classes.label }}
-                      control={
-                        <BlueCheckbox
-                          name={header}
-                          color='primary'
-                          onClick={handleCheckboxClick}
-                          checked={filters.includes(header)}
-                        />
-                      }
-                    />
-                  ))}
+        <Extensible onRenderItems={onRenderSettings}>
+          <FormGroup row classes={{ row: classes.formGroup }}>
+            {!hideMarkdownToggle && (
+              <FormControlLabel
+                control={
+                  <BlueSwitch
+                    name='markdownView'
+                    checked={markdownView}
+                    onClick={() => onShowMarkdown(!markdownView)}
+                  />
+                }
+                classes={{ label: classes.switchLabel }}
+                label='Markdown View'
+                labelPlacement='bottom'
+              />
+            )}
+            {!!getCustomComponent && getCustomComponent()}
+          </FormGroup>
+          <Divider />
+          <div className={classes.fontSlider}>
+            <FontSizeSlider value={fontSize} onChange={setFontSize} />
+          </div>
+          {!disableFilters && headers && headers.length > 0 && (
+            <Fragment>
+              <Divider />
+              <div className={classes.section}>
+                <div className={classes.columns}>
+                  <Typography
+                    classes={{ root: classes.typography }}
+                    variant='caption'
+                    display='block'
+                    gutterBottom
+                  >
+                    Show Columns
+                  </Typography>
+                  <div className={classes.checkboxes}>
+                    {headers.map((header, i) => (
+                      <FormControlLabel
+                        key={`${i}-${header}`}
+                        label={header}
+                        classes={{ root: classes.label }}
+                        control={
+                          <BlueCheckbox
+                            name={header}
+                            color='primary'
+                            onClick={handleCheckboxClick}
+                            checked={filters.includes(header)}
+                          />
+                        }
+                      />
+                    ))}
+                  </div>
                 </div>
               </div>
-            </div>
-          </Fragment>
-        )}
-        {!!onRemoveCard && (
-          <>
-            <Divider />
-            <div className={classes.cardRemovalSection}>
-              <div className={classes.removeText} onClick={onRemoveCard}>
-                Remove Resource Card
+            </Fragment>
+          )}
+          {!!onRemoveCard && (
+            <>
+              <Divider />
+              <div className={classes.cardRemovalSection}>
+                <div className={classes.removeText} onClick={onRemoveCard}>
+                  Remove Resource Card
+                </div>
               </div>
-            </div>
-          </>
-        )}
+            </>
+          )}
+        </Extensible>
       </Card>
     </DraggableModal>
   )

--- a/src/components/SettingsCard/SettingsCard.js
+++ b/src/components/SettingsCard/SettingsCard.js
@@ -135,7 +135,11 @@ const SettingsCard = ({
         }}
       >
         <Extensible onRenderItems={onRenderSettings}>
-          <FormGroup row classes={{ row: classes.formGroup }}>
+          <FormGroup
+            row
+            key='markdown-view-setting'
+            classes={{ row: classes.formGroup }}
+          >
             {!hideMarkdownToggle && (
               <FormControlLabel
                 control={
@@ -152,12 +156,12 @@ const SettingsCard = ({
             )}
             {!!getCustomComponent && getCustomComponent()}
           </FormGroup>
-          <Divider />
-          <div className={classes.fontSlider}>
+          <Divider key='divider' />
+          <div className={classes.fontSlider} key='font-slider-setting'>
             <FontSizeSlider value={fontSize} onChange={setFontSize} />
           </div>
           {!disableFilters && headers && headers.length > 0 && (
-            <Fragment>
+            <Fragment key='filters-setting'>
               <Divider />
               <div className={classes.section}>
                 <div className={classes.columns}>
@@ -191,14 +195,14 @@ const SettingsCard = ({
             </Fragment>
           )}
           {!!onRemoveCard && (
-            <>
+            <Fragment key='remove-resource-setting'>
               <Divider />
               <div className={classes.cardRemovalSection}>
                 <div className={classes.removeText} onClick={onRemoveCard}>
                   Remove Resource Card
                 </div>
               </div>
-            </>
+            </Fragment>
           )}
         </Extensible>
       </Card>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@gwdevs/extensible-rcl@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@gwdevs/extensible-rcl/-/extensible-rcl-1.0.0.tgz#daecfb5c16828c58411546a8aaaa1e552028883e"
+  integrity sha512-SryCMnRaviW0CKJpGkFF5acS/B8zsf1kwVYzeLu0+NGooNVFe1oCIVCtOgt6A7nYINGM9qOnWrxFlUe0O8FTww==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Make the toolbar of the Card component and the SettingsCard component extensible.

Now both components have an `onRender...` prop which is a callback function that would allow the RCL consumer to hook into the rendering of the wrapped elements

## Test Instructions

- [ ] Create a Component that renders a Card component
- [ ] Add the onRenderToolbar prop to the Card
- [ ] Create an onRenderToolbar function with `{items}` as the argument
- [ ] Make the onRenderToolbar return modified items i.e `({items}) => [...items, "example"]`
- [ ] Add onRenderToolbar function to the onRenderToolbar prop of Card
- [ ] Do the same with onRenderSettings.

Resulting code:

```js
const Component = () => {
  const onRenderToolbar = ({items}) => [...items,"example"]
  const onRenderSettings = ({items}) => [...items,"example"]

  return (
    <Card
      onRenderToolbar={onRenderToolbar}
      onRenderSettings={onRenderSettings}
    >
    </Card>
  )
}
```

Returning jsx instead of array: 

```js
const Component = () => {
  const onRenderToolbar = ({items}) => <>{items}{"example"}</>
  const onRenderSettings = ({items}) => <>{items}{"example"}</>

  return (
    <Card
      onRenderToolbar={onRenderToolbar}
      onRenderSettings={onRenderSettings}
    >
    </Card>
  )
}
```