### PR TITLE
useCallback so PaperComponent is not re-mounted every time

### DIFF
--- a/src/components/DraggableModal/DraggableModal.js
+++ b/src/components/DraggableModal/DraggableModal.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import Dialog from '@mui/material/Dialog'
 import Draggable from 'react-draggable'
@@ -13,7 +13,7 @@ export default function DraggableModal({
   initialPosition,
  }) {
 
-  function PaperComponent(props) {
+  const PaperComponent = useCallback( (props) => {
     function onStart(e) {
       if (onStartDrag) {
         return onStartDrag(e)
@@ -32,7 +32,7 @@ export default function DraggableModal({
         <div {...props} />
       </Draggable>
     )
-  }
+  }, [onStartDrag, bounds, initialPosition])
 
   return (
     <Dialog

--- a/src/components/DraggableModal/DraggableModal.md
+++ b/src/components/DraggableModal/DraggableModal.md
@@ -5,14 +5,19 @@ Draggable Modal.
 ```jsx
 import React, { useState } from 'react'
 import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
 import Card from '../Card'
 
 const Component = () => {
   const [showModal, setShowModal] = useState(false)
+  const [value, setValue] = useState('')
 
   const handleClickClose = () => setShowModal(false)
   const handleClickOpen = () => setShowModal(true)
 
+  const onChangeHandler = event => {
+	  setValue(event.target.value)
+  }
   return (
     <div>
       <Button variant="outlined" color="primary" onClick={handleClickOpen}>
@@ -33,6 +38,7 @@ const Component = () => {
           <div style={{ padding: '45px', fontWeight: 'bold' }}>
             Hello! You can drag me by holding on the drag icon.
           </div>
+          <TextField label="TextField should not loose focus" type="url" value={value} onChange={onChangeHandler} />
         </Card>
       </DraggableModal>
     </div>


### PR DESCRIPTION
## Describe what your pull request addresses
For https://github.com/unfoldingWord/gateway-translation/issues/8 We needed to add a controlled TextField inside a Draggable Modal. Without this change the text field would loose focus with each keystroke making it almost impossible to type anything. 

This is because declaring the PaperComponent in the render function caused it to re-mount the whole component. `useCallback` fixes this problem. 
See https://www.developerway.com/posts/react-re-renders-guide#part3.1

## Test Instructions

- [ ] Try to type in the TextField of the DraggableModel in styleguidist. It should not loose focus with each keystroke.
