### PR TITLE
Return pure setItemIndex function and allow disable click in TWL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translation-helps-rcl",
-    "version": "3.5.11",
+    "version": "3.5.12",
     "main": "dist/index.js",
     "homepage": "https://translation-helps-rcl.netlify.app/",
     "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/components/CardContent/CardContent.js
+++ b/src/components/CardContent/CardContent.js
@@ -23,6 +23,7 @@ const CardContent = ({
   errorMessage,
   twlActionButtons,
   selectedQuote,
+  shouldDisableClick,
   cardResourceId,
   updateTaDetails,
   fontSize: _fontSize,
@@ -87,6 +88,7 @@ const CardContent = ({
         setItemIndex={setItemIndex}
         selectedQuote={selectedQuote}
         showSaveChangesPrompt={showSaveChangesPrompt}
+        shouldDisableClick={shouldDisableClick}
       />
     )
   } else if (
@@ -149,7 +151,7 @@ CardContent.defaultProps = {
   fontSize: 100,
   editable: false,
   isLoading: false,
-  onEdit: () => { },
+  onEdit: () => {},
   viewMode: 'default',
 }
 
@@ -167,6 +169,7 @@ CardContent.propTypes = {
   markdownView: PropTypes.bool,
   errorMessage: PropTypes.string,
   selectedQuote: PropTypes.object,
+  shouldDisableClick: PropTypes.bool,
   setItemIndex: PropTypes.func,
   viewMode: PropTypes.oneOf([
     'default',

--- a/src/components/TsvList/TsvList.js
+++ b/src/components/TsvList/TsvList.js
@@ -34,6 +34,7 @@ export default function TsvList({
   setItemIndex,
   selectedQuote,
   showSaveChangesPrompt,
+  shouldDisableClick,
 }) {
   let filteredItems = []
   let headers = []
@@ -106,6 +107,7 @@ export default function TsvList({
                   renderedActionButtons={renderedActionButtons}
                   setContent={setContent}
                   setItemIndex={setItemIndex}
+                  shouldDisableClick={shouldDisableClick}
                   selectedQuote={selectedQuote}
                   SupportReference={SupportReference}
                   showSaveChangesPrompt={showSaveChangesPrompt}
@@ -127,6 +129,7 @@ TsvList.propTypes = {
   setCurrentCheck: PropTypes.func,
   setItemIndex: PropTypes.func,
   selectedQuote: PropTypes.object,
+  shouldDisableClick: PropTypes.bool,
   filters: PropTypes.array.isRequired,
   fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
@@ -145,6 +148,7 @@ function Row({
   renderedActionButtons,
   setContent,
   setItemIndex,
+  shouldDisableClick,
   selectedQuote,
   SupportReference,
   showSaveChangesPrompt,
@@ -172,6 +176,7 @@ function Row({
       style={style}
       onClick={() => {
         // Check if tw has been edited in order to not lose unsaved changes when selecting a twl item.
+        if (shouldDisableClick) return
         showSaveChangesPrompt('tw', setContent).then(() => {
           if (setCurrentCheck && !selected) {
             if (newQuote) {

--- a/src/hooks/useCardState.js
+++ b/src/hooks/useCardState.js
@@ -151,6 +151,7 @@ const useCardState = ({
       setFilters,
       setFontSize,
       setItemIndex: setItem,
+      setItemIndexPure: setItemIndex,
       setMarkdownView,
     },
   }


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Return pure setItemIndex function and allow disable click in TWL

## Test Instructions

- [ ] Open [Deploy Preview]()
- [ ] Open console and see "new Quote" console log when clicking on any TWL item
  - [ ] Verify that this console log is not being fired off twice for each click (Functionality of pure setItemIndex)
  - [ ] Open either the add or delete row Item dialog and verify that the same console log does not fire when clicking in the dialog
