### PR TITLE
Check for string value in setItem so empty string is valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translation-helps-rcl",
-    "version": "3.5.13",
+    "version": "3.5.14",
     "main": "dist/index.js",
     "homepage": "https://translation-helps-rcl.netlify.app/",
     "repository": "https://github.com/unfoldingWord/translation-helps-rcl.git",

--- a/src/hooks/useCardState.js
+++ b/src/hooks/useCardState.js
@@ -122,8 +122,8 @@ const useCardState = ({
 
       if (
         setCurrentCheck &&
-        (Quote || OrigQuote) &&
-        Occurrence &&
+        (typeof Quote === 'string' || typeof OrigQuote === 'string') &&
+        typeof Occurrence === 'string' &&
         typeof SupportReference === 'string'
       ) {
         setCurrentCheck({


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Addreses fix for [Gateway Edit #601](https://github.com/unfoldingWord/gateway-edit/issues/601)
- [ ] Change setItem to only pass in `null` to `setCurrentCheck` if needed values are not string (will be undefined if not present in items)

## Test Instructions

- [ ] Open [Deploy Preview](https://deploy-preview-603--gateway-edit.netlify.app/)
- [ ] Navigate to Habakkuk in unfoldingWord org (some other books did not show the same problem. The race condition did not affect smaller books)
- [ ] Add a new TN that has a reference range (i.e 1:1-3)
  - [ ] Navigate to the newly created note.
  - [ ] Verify that the scripture card panes are showing the verses for the reference range that was input. For example, if you input a reference range of 1:1-3, you should see all three verses in the scripture cards
